### PR TITLE
rust sdk name changed for crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "graphlite-sdk"
+name = "graphlite-rust-sdk"
 version = "0.0.1"
 dependencies = [
  "graphlite",

--- a/graphlite-sdk/Cargo.toml
+++ b/graphlite-sdk/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "graphlite-sdk"
+name = "graphlite-rust-sdk"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true


### PR DESCRIPTION
in cargo.toml the rust sdk directory the name was changed to graphlite-rust-sdk. This was done for publishing purposes of the crate in Rust's official directory of crates. 