### PR TITLE
fix(GQL): ORDER BY clause not sorting results correctly

### DIFF
--- a/graphlite/src/exec/executor.rs
+++ b/graphlite/src/exec/executor.rs
@@ -6661,6 +6661,40 @@ impl QueryExecutor {
         Ok(current_paths)
     }
 
+    /// Evaluates an ORDER BY expression against a row.
+    ///
+    /// This helper injects row values into the context with both:
+    /// - Aliased column names (e.g., `age` from `p.age AS age`)
+    /// - Original property paths (e.g., `p.age`)
+    ///
+    /// This dual binding is necessary because ORDER BY expressions may reference
+    /// the original property path (e.g., `ORDER BY p.age`) while row values are
+    /// stored under aliased names. Without this, the expression would resolve
+    /// to stale values from the base context instead of the current row.
+    fn eval_order_by_expression(
+        &self,
+        expr: &Expression,
+        row_values: &std::collections::HashMap<String, Value>,
+        base_context: &ExecutionContext,
+        prop_access: Option<&PropertyAccess>,
+    ) -> Result<Value, ExecutionError> {
+        let mut ctx = base_context.clone();
+
+        for (k, v) in row_values {
+            ctx.set_variable(k.clone(), v.clone());
+
+            // Also set the prefixed version (e.g., "p.age") when the property matches
+            if let Some(prop) = prop_access {
+                if prop.property == *k {
+                    let prefixed = format!("{}.{}", prop.object, prop.property);
+                    ctx.set_variable(prefixed, v.clone());
+                }
+            }
+        }
+
+        self.evaluate_expression(expr, &ctx)
+    }
+
     /// Execute in-memory sort operation
     fn execute_in_memory_sort(
         &self,
@@ -6671,34 +6705,16 @@ impl QueryExecutor {
         // Sort the rows based on the sort expressions
         input_rows.sort_by(|a, b| {
             for sort_item in sort_expressions {
-                // Evaluate the sort expression for both rows using cloned context
-                let mut context_a = context.clone();
-                for (k, v) in &a.values {
-                    context_a.set_variable(k.clone(), v.clone());
-                    // Also set the prefixed version (e.g., "p.age" in addition to "age")
-                    // This handles ORDER BY expressions that use the original property path
-                    // while rows have aliased column names
-                    if let Expression::PropertyAccess(prop) = &sort_item.expression {
-                        if prop.property == *k {
-                            let prefixed = format!("{}.{}", prop.object, prop.property);
-                            context_a.set_variable(prefixed, v.clone());
-                        }
-                    }
-                }
-                let val_a = self.evaluate_expression(&sort_item.expression, &context_a);
+                // Pre-extract PropertyAccess once per sort item (not per row value)
+                let prop_access = match &sort_item.expression {
+                    Expression::PropertyAccess(p) => Some(p),
+                    _ => None,
+                };
 
-                let mut context_b = context.clone();
-                for (k, v) in &b.values {
-                    context_b.set_variable(k.clone(), v.clone());
-                    // Also set the prefixed version for context_b
-                    if let Expression::PropertyAccess(prop) = &sort_item.expression {
-                        if prop.property == *k {
-                            let prefixed = format!("{}.{}", prop.object, prop.property);
-                            context_b.set_variable(prefixed, v.clone());
-                        }
-                    }
-                }
-                let val_b = self.evaluate_expression(&sort_item.expression, &context_b);
+                let val_a =
+                    self.eval_order_by_expression(&sort_item.expression, &a.values, context, prop_access);
+                let val_b =
+                    self.eval_order_by_expression(&sort_item.expression, &b.values, context, prop_access);
 
                 match (val_a, val_b) {
                     (Ok(a_val), Ok(b_val)) => {

--- a/graphlite/src/exec/executor.rs
+++ b/graphlite/src/exec/executor.rs
@@ -6711,10 +6711,18 @@ impl QueryExecutor {
                     _ => None,
                 };
 
-                let val_a =
-                    self.eval_order_by_expression(&sort_item.expression, &a.values, context, prop_access);
-                let val_b =
-                    self.eval_order_by_expression(&sort_item.expression, &b.values, context, prop_access);
+                let val_a = self.eval_order_by_expression(
+                    &sort_item.expression,
+                    &a.values,
+                    context,
+                    prop_access,
+                );
+                let val_b = self.eval_order_by_expression(
+                    &sort_item.expression,
+                    &b.values,
+                    context,
+                    prop_access,
+                );
 
                 match (val_a, val_b) {
                     (Ok(a_val), Ok(b_val)) => {

--- a/graphlite/tests/order_by_desc_test.rs
+++ b/graphlite/tests/order_by_desc_test.rs
@@ -1,0 +1,210 @@
+//! Test for ORDER BY DESC functionality
+//!
+//! This test verifies that ORDER BY with DESC direction correctly sorts results
+//! in descending order.
+
+#[path = "testutils/mod.rs"]
+mod testutils;
+
+use graphlite::Value;
+use testutils::test_fixture::TestFixture;
+
+#[test]
+fn test_order_by_desc_simple() {
+    let fixture = TestFixture::new().expect("Failed to create fixture");
+
+    // Setup graph
+    fixture
+        .setup_graph("order_test")
+        .expect("Failed to setup graph");
+
+    // Insert test data with different ages
+    fixture
+        .query("INSERT (:Person {name: 'Alice', age: 30})")
+        .expect("Failed to insert Alice");
+    fixture
+        .query("INSERT (:Person {name: 'Bob', age: 25})")
+        .expect("Failed to insert Bob");
+    fixture
+        .query("INSERT (:Person {name: 'Charlie', age: 35})")
+        .expect("Failed to insert Charlie");
+
+    // Query with ORDER BY DESC - should return Charlie (35), Alice (30), Bob (25)
+    let result = fixture
+        .query("MATCH (p:Person) RETURN p.name as name, p.age as age ORDER BY p.age DESC")
+        .expect("Query with ORDER BY DESC should succeed");
+
+    // Extract ages in order
+    let ages: Vec<f64> = result
+        .rows
+        .iter()
+        .filter_map(|row| row.values.get("age"))
+        .filter_map(|v| {
+            if let Value::Number(n) = v {
+                Some(*n)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    println!("ORDER BY DESC - Ages in result order: {:?}", ages);
+    println!("Expected: [35.0, 30.0, 25.0]");
+
+    // With DESC order: Charlie (35) should be first, Alice (30) second, Bob (25) third
+    assert_eq!(
+        ages,
+        vec![35.0, 30.0, 25.0],
+        "ORDER BY p.age DESC should sort ages in descending order"
+    );
+}
+
+#[test]
+fn test_order_by_asc_simple() {
+    let fixture = TestFixture::new().expect("Failed to create fixture");
+
+    // Setup graph
+    fixture
+        .setup_graph("order_asc_test")
+        .expect("Failed to setup graph");
+
+    // Insert test data with different ages
+    fixture
+        .query("INSERT (:Person {name: 'Alice', age: 30})")
+        .expect("Failed to insert Alice");
+    fixture
+        .query("INSERT (:Person {name: 'Bob', age: 25})")
+        .expect("Failed to insert Bob");
+    fixture
+        .query("INSERT (:Person {name: 'Charlie', age: 35})")
+        .expect("Failed to insert Charlie");
+
+    // Query with ORDER BY ASC - should return Bob (25), Alice (30), Charlie (35)
+    let result = fixture
+        .query("MATCH (p:Person) RETURN p.name as name, p.age as age ORDER BY p.age ASC")
+        .expect("Query with ORDER BY ASC should succeed");
+
+    // Extract ages in order
+    let ages: Vec<f64> = result
+        .rows
+        .iter()
+        .filter_map(|row| row.values.get("age"))
+        .filter_map(|v| {
+            if let Value::Number(n) = v {
+                Some(*n)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    println!("ORDER BY ASC - Ages in result order: {:?}", ages);
+    println!("Expected: [25.0, 30.0, 35.0]");
+
+    // With ASC order: Bob (25) should be first, Alice (30) second, Charlie (35) third
+    assert_eq!(
+        ages,
+        vec![25.0, 30.0, 35.0],
+        "ORDER BY p.age ASC should sort ages in ascending order"
+    );
+}
+
+#[test]
+fn test_order_by_default_is_asc() {
+    let fixture = TestFixture::new().expect("Failed to create fixture");
+
+    // Setup graph
+    fixture
+        .setup_graph("order_default_test")
+        .expect("Failed to setup graph");
+
+    // Insert test data with different ages
+    fixture
+        .query("INSERT (:Person {name: 'Alice', age: 30})")
+        .expect("Failed to insert Alice");
+    fixture
+        .query("INSERT (:Person {name: 'Bob', age: 25})")
+        .expect("Failed to insert Bob");
+    fixture
+        .query("INSERT (:Person {name: 'Charlie', age: 35})")
+        .expect("Failed to insert Charlie");
+
+    // Query with ORDER BY (no direction) - should default to ASC
+    let result = fixture
+        .query("MATCH (p:Person) RETURN p.name as name, p.age as age ORDER BY p.age")
+        .expect("Query with ORDER BY (default) should succeed");
+
+    // Extract ages in order
+    let ages: Vec<f64> = result
+        .rows
+        .iter()
+        .filter_map(|row| row.values.get("age"))
+        .filter_map(|v| {
+            if let Value::Number(n) = v {
+                Some(*n)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    println!("ORDER BY (default) - Ages in result order: {:?}", ages);
+    println!("Expected: [25.0, 30.0, 35.0]");
+
+    // Default should be ASC: Bob (25) first, Alice (30) second, Charlie (35) third
+    assert_eq!(
+        ages,
+        vec![25.0, 30.0, 35.0],
+        "ORDER BY p.age (default) should sort ages in ascending order"
+    );
+}
+
+#[test]
+fn test_order_by_desc_with_where() {
+    let fixture = TestFixture::new().expect("Failed to create fixture");
+
+    // Setup graph
+    fixture
+        .setup_graph("order_where_test")
+        .expect("Failed to setup graph");
+
+    // Insert test data with different ages
+    fixture
+        .query("INSERT (:Person {name: 'Alice', age: 30})")
+        .expect("Failed to insert Alice");
+    fixture
+        .query("INSERT (:Person {name: 'Bob', age: 25})")
+        .expect("Failed to insert Bob");
+    fixture
+        .query("INSERT (:Person {name: 'Charlie', age: 35})")
+        .expect("Failed to insert Charlie");
+
+    // Query with WHERE and ORDER BY DESC - only ages > 25
+    let result = fixture
+        .query("MATCH (p:Person) WHERE p.age > 25 RETURN p.name as name, p.age as age ORDER BY p.age DESC")
+        .expect("Query with WHERE and ORDER BY DESC should succeed");
+
+    // Extract ages in order
+    let ages: Vec<f64> = result
+        .rows
+        .iter()
+        .filter_map(|row| row.values.get("age"))
+        .filter_map(|v| {
+            if let Value::Number(n) = v {
+                Some(*n)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    println!("WHERE + ORDER BY DESC - Ages in result order: {:?}", ages);
+    println!("Expected: [35.0, 30.0]");
+
+    // With WHERE p.age > 25 and DESC: Charlie (35) first, Alice (30) second
+    assert_eq!(
+        ages,
+        vec![35.0, 30.0],
+        "WHERE p.age > 25 ORDER BY p.age DESC should return [35, 30]"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #45 describing how `ORDER BY` fails to correctly sort query results. 

## Problem

The issue is observed whilst sorting using aliased columns.
The sort logic was using the original property path (`p.age`) while row values used the alias (`age`), causing a stale value to be read and all rows to compare as equal.

## Solution

When setting row values in the sort context, also set the prefixed version (e.g., `p.age`) when the property name matches the aliased column name. This ensures the sort expression can correctly resolve property values for each row being compared.

## Added Test Suite 
Added multiple test cases covering common scenarios (fail without the fix):

- Verify DESC sorting works correctly
- Verify ASC sorting works correctly
- Verify default sort order is ASC
- Verify ORDER BY works with WHERE clause

With the fix checked in, the full test suite passes with no regressions

## Tests for reviewers

1. Create a simple graph:
```
INSERT (:Person {name: 'Alice', age: 30}),
       (:Person {name: 'Bob', age: 25}),
       (:Person {name: 'Charlie', age: 35});
```   
2. Query with ORDER BY DESC:
```
MATCH (p:Person) RETURN p.name as name, p.age as age ORDER BY p.age DESC;
```

3. Expected results
```
admin::gql> MATCH (p:Person) RETURN p.name as name, p.age as age ORDER BY p.age DESC;
Query Results
Execution time: 0 ms
Rows returned: 3

┌─────────┬─────┐
│ name    ┆ age │
╞═════════╪═════╡
│ Charlie ┆ 35  │
├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┤
│ Alice   ┆ 30  │
├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┤
│ Bob     ┆ 25  │
└─────────┴─────┘
```

